### PR TITLE
Fix incorrect color check in home team kit setup

### DIFF
--- a/Assets/Scripts/Managers/PlayerTokenManager.cs
+++ b/Assets/Scripts/Managers/PlayerTokenManager.cs
@@ -128,7 +128,7 @@ public class PlayerTokenManager : MonoBehaviour
         {
             CreateTeam(redKitPrefab, "Home", homeTeamHexes);
         }
-        else if (homeKit == "Bluw")
+        else if (homeKit == "Blue")
         {
             CreateTeam(blueKitPrefab, "Home", homeTeamHexes);
         }
@@ -191,7 +191,7 @@ public class PlayerTokenManager : MonoBehaviour
         {
             CreateTeam(redKitPrefab, "Home", homeTeamHexes);
         }
-        else if (homeKit == "Bluw")
+        else if (homeKit == "Blue")
         {
             CreateTeam(blueKitPrefab, "Home", homeTeamHexes);
         }


### PR DESCRIPTION
## Summary
- correct typo in PlayerTokenManager that prevented blue home kits

## Testing
- `# no tests available`


------
https://chatgpt.com/codex/tasks/task_e_68405e14d9d483319439a645a4cf699c