### PR TITLE
Fix accuracy roll flags

### DIFF
--- a/Assets/Scripts/ActionScripts/GameTestScenarioRunner.cs
+++ b/Assets/Scripts/ActionScripts/GameTestScenarioRunner.cs
@@ -45,13 +45,13 @@ public class GameStatusSnapshot
     public bool hpmIsWaitingforAttackerSelection;
     public bool hpmIsWaitingforDefenderSelection;
     public HexCell hpmCurrentTargetHex;
-    public bool hpmisWaitingForAccuracyRoll;
+    public bool hpmIsWaitingForAccuracyRoll;
     public bool hpmIsWaitingForDirectionRoll;
     public bool hpmIsWaitingForDistanceRoll;
     public bool lbmAvailable;
     public bool lbmIsActivated;
     public bool lbmIsAwaitingTargetSelection;
-    public bool lbmIsWaiitngForAccuracyRoll;
+    public bool lbmIsWaitingForAccuracyRoll;
     public bool lbmIsWaitingForDirectionRoll;
     public bool lbmIsWaitingForDistanceRoll;
     public bool lbmIsWaitingForDefLBMove;
@@ -85,12 +85,12 @@ public class GameStatusSnapshot
         hpmIsWaitingforAttackerSelection = hpm.isWaitingForAttackerSelection;
         hpmIsWaitingforDefenderSelection = hpm.isWaitingForDefenderSelection;
         hpmCurrentTargetHex = hpm.currentTargetHex;
-        hpmisWaitingForAccuracyRoll = hpm.isWaitingForAccuracyRoll;
+        hpmIsWaitingForAccuracyRoll = hpm.isWaitingForAccuracyRoll;
         hpmIsWaitingForDirectionRoll = hpm.isWaitingForDirectionRoll;
         hpmIsWaitingForDistanceRoll = hpm.isWaitingForDistanceRoll;
         lbmAvailable = lbm.isAvailable;
         lbmIsActivated = lbm.isActivated;
-        lbmIsWaiitngForAccuracyRoll = lbm.isWaitingForAccuracyRoll;
+        lbmIsWaitingForAccuracyRoll = lbm.isWaitingForAccuracyRoll;
         lbmIsWaitingForDirectionRoll = lbm.isWaitingForDirectionRoll;
         lbmIsWaitingForDistanceRoll = lbm.isWaitingForDistanceRoll;
         lbmIsAwaitingTargetSelection = lbm.isAwaitingTargetSelection;
@@ -196,9 +196,9 @@ public class GameStatusSnapshot
             mismatches.Add($"HighPassManager.currentTargetHex mismatch: {hpmCurrentTargetHex?.name} vs {other.hpmCurrentTargetHex?.name}");
         }
 
-        if (excludeFields?.Contains("hpmisWaitingForAccuracyRoll") != true && hpmisWaitingForAccuracyRoll != other.hpmisWaitingForAccuracyRoll)
+        if (excludeFields?.Contains("hpmIsWaitingForAccuracyRoll") != true && hpmIsWaitingForAccuracyRoll != other.hpmIsWaitingForAccuracyRoll)
         {
-            mismatches.Add($"HighPassManager.isWaitingForAccuracyRoll mismatch: {hpmisWaitingForAccuracyRoll} vs {other.hpmisWaitingForAccuracyRoll}");
+            mismatches.Add($"HighPassManager.isWaitingForAccuracyRoll mismatch: {hpmIsWaitingForAccuracyRoll} vs {other.hpmIsWaitingForAccuracyRoll}");
         }
         
         if (excludeFields?.Contains("hpmIsWaitingForDirectionRoll") != true && hpmIsWaitingForDirectionRoll != other.hpmIsWaitingForDirectionRoll)
@@ -221,9 +221,9 @@ public class GameStatusSnapshot
             mismatches.Add($"LongBallManager.isActivated mismatch: {lbmIsActivated} vs {other.lbmIsActivated}");
         }
         
-        if (excludeFields?.Contains("lbmIsWaiitngForAccuracyRoll") != true && lbmIsWaiitngForAccuracyRoll != other.lbmIsWaiitngForAccuracyRoll)
+        if (excludeFields?.Contains("lbmIsWaitingForAccuracyRoll") != true && lbmIsWaitingForAccuracyRoll != other.lbmIsWaitingForAccuracyRoll)
         {
-            mismatches.Add($"LongBallManager.isWaitingForAccuracyRoll mismatch: {lbmIsWaiitngForAccuracyRoll} vs {other.lbmIsWaiitngForAccuracyRoll}");
+            mismatches.Add($"LongBallManager.isWaitingForAccuracyRoll mismatch: {lbmIsWaitingForAccuracyRoll} vs {other.lbmIsWaitingForAccuracyRoll}");
         }
         
         if (excludeFields?.Contains("lbmIsWaitingForDirectionRoll") != true && lbmIsWaitingForDirectionRoll != other.lbmIsWaitingForDirectionRoll)


### PR DESCRIPTION
## Summary
- fix typos in `GameTestScenarioRunner` accuracy roll flags

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441a1e96d08331be1d296b369231cd